### PR TITLE
make rss tag logic match the route

### DIFF
--- a/src/Twig/RSSExtension.php
+++ b/src/Twig/RSSExtension.php
@@ -3,7 +3,9 @@
 namespace OHMedia\NewsBundle\Twig;
 
 use OHMedia\NewsBundle\Entity\Article;
+use OHMedia\PageBundle\Service\PageRawQuery;
 use OHMedia\SettingsBundle\Service\Settings;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
@@ -13,6 +15,9 @@ class RSSExtension extends AbstractExtension
     public function __construct(
         private Settings $settings,
         private UrlGeneratorInterface $urlGenerator,
+        private PageRawQuery $pageRawQuery,
+        #[Autowire('%oh_media_news.page_template%')]
+        private string $pageTemplate,
     ) {
     }
 
@@ -27,6 +32,12 @@ class RSSExtension extends AbstractExtension
 
     public function rssLinkTag(): string
     {
+        $pagePath = $this->pageRawQuery->getPathWithTemplate($this->pageTemplate);
+
+        if (!$pagePath) {
+            return '';
+        }
+
         $title = (string) $this->settings->get(Article::SETTING_RSS_TITLE);
         $href = $this->urlGenerator->generate('news_rss');
 


### PR DESCRIPTION
The dead link checker found the RSS tag URL and tried to get to the RSS route which gave back a 404.